### PR TITLE
Wget instead of Curl in minimal configuration setup

### DIFF
--- a/lib/hospice/templates/Vagrantfile.erb
+++ b/lib/hospice/templates/Vagrantfile.erb
@@ -7,7 +7,7 @@ Vagrant::Config.run do |config|
 
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-  config.vm.provision :shell, :inline => "curl -L https://www.opscode.com/chef/install.sh | bash"
+  config.vm.provision :shell, :inline => "wget -O - https://www.opscode.com/chef/install.sh | sudo bash"
   config.ssh.forward_agent = true
 
   config.vm.provision :chef_solo do |chef|


### PR DESCRIPTION
Official Vagrant Ubuntu boxes don't have curl in minimal configuration (in case of usages few recipes only)
