### PR TITLE
Fixing typo that caused crashes from #38

### DIFF
--- a/vagrant_settings/vm_settings.rb
+++ b/vagrant_settings/vm_settings.rb
@@ -1,4 +1,4 @@
-Rove.vagrant_settings :vm_params do
+Rove.vagrant_setting :vm_params do
 
   config do |cpus, memory|
     "config.vm.provider \"virtualbox\" do |vb|


### PR DESCRIPTION
In #38 I accidentally introduced a typo, yet the build passed (?) but the server didn't start on my machine anymore. In that rare case I didn't test it locally before pushing... I failed :(
